### PR TITLE
fix: URL parsing error when document.referrer is empty

### DIFF
--- a/js/interwiki.js
+++ b/js/interwiki.js
@@ -109,7 +109,7 @@ export function createInterwiki(
   var site = document.referrer;
 
   // Extract domain and protocol only (for SCP-JP localization)
-  var url = new URL(site);
+  var url = new URL(site || window.location.href);
   site = url.protocol + "//" + url.hostname;
 
   var frameId = location.href.replace(/^.*\//, "/");


### PR DESCRIPTION
Handled cases where document.referrer is not available, defaulting to window.location.href to prevent URL constructor errors.
![image](https://github.com/user-attachments/assets/9a29f523-eac5-4872-940b-250b5bd8e9ad)

current version:
https://interwiki.scp-jp.org/interwikiFrame.html?lang=jp&community=scp&pagename=main

PR version:
https://interwikidev.scp-jp.org/interwikiFrame.html?lang=jp&community=scp&pagename=main
